### PR TITLE
Fix for GTF files with comment lines

### DIFF
--- a/bin/filter_ensembl.py
+++ b/bin/filter_ensembl.py
@@ -20,6 +20,8 @@ def main():
         if len(line) == 0:
             break;
         line = string.strip(line)
+        if line.startswith("#"):
+            continue;
         annoPart = string.split(line, sep="\t")[-1][:-1].replace("\"", "")
         # annoPartL = string.split(annoPart, sep=";")
         source = line.split("\t")[1]  # LS.


### PR DESCRIPTION
GTF files from ensembl have comment lines.
this patch allows for the script to ignore comment lines and keep running, it is currently crashing
